### PR TITLE
Refactor thesis editors and docx utils

### DIFF
--- a/src/ThesisForm.jsx
+++ b/src/ThesisForm.jsx
@@ -1,230 +1,175 @@
-import React, { useState } from "react";
+import React, { useReducer } from "react";
 import { Button } from "./components/ui/button";
 import { Card, CardContent } from "./components/ui/card";
 import { Input } from "./components/ui/input";
 import { Textarea } from "./components/ui/textarea";
-import { Document, Packer, Paragraph, HeadingLevel, TextRun, Table, TableRow, TableCell, TableOfContents } from "docx";
+import ChapterEditor from "./components/thesis/ChapterEditor";
+import { generateDocx } from "./utils/docx";
 
 const defaultUniversity = "國立中央大學";
 
-function emptyChapter() {
-  return { title: "", sections: [emptySection()] };
-}
-function emptySection() {
-  return { title: "", subsections: [emptySubsection()] };
-}
-function emptySubsection() {
-  return { title: "", content: "" };
-}
+let idCounter = 0;
+const genId = () => ++idCounter;
 
-// 判斷是否為簡單 Markdown 表格
-function isMarkdownTable(text) {
-  return text.trim().split("\n")[0].trim().startsWith("|") && text.includes("|---");
-}
-// 將簡單 Markdown 表格轉為 docx.js Table
-function parseMarkdownTable(md) {
-  const lines = md.trim().split("\n").filter(Boolean);
-  if (lines.length < 2) return null;
-  const rows = lines.filter(l => l.trim().startsWith("|"));
-  const data = rows.map(r => r.split("|").slice(1, -1).map(cell => cell.trim()));
-  // 去掉 header 分隔線
-  const tableRows = data.filter(row => !row.every(cell => cell.match(/^[-:]+$/)));
-  return new Table({
-    rows: tableRows.map(row => new TableRow({
-      children: row.map(cell => new TableCell({
-        children: [new Paragraph(cell)]
-      }))
-    }))
-  });
+const emptySubsection = () => ({ id: genId(), title: "", content: "" });
+const emptySection = () => ({ id: genId(), title: "", subsections: [emptySubsection()] });
+const emptyChapter = () => ({ id: genId(), title: "", sections: [emptySection()] });
+
+const initialState = {
+  title: "",
+  author: "",
+  advisor: "",
+  university: defaultUniversity,
+  year: "",
+  department: "",
+  abstract: "",
+  keywords: "",
+  chapters: [emptyChapter()],
+  bibliography: "",
+};
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "setField":
+      return { ...state, [action.field]: action.value };
+    case "addChapter":
+      return { ...state, chapters: [...state.chapters, emptyChapter()] };
+    case "removeChapter":
+      return { ...state, chapters: state.chapters.filter(ch => ch.id !== action.id) };
+    case "setChapterField":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.id ? { ...ch, [action.field]: action.value } : ch
+        ),
+      };
+    case "addSection":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? { ...ch, sections: [...ch.sections, emptySection()] }
+            : ch
+        ),
+      };
+    case "removeSection":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? { ...ch, sections: ch.sections.filter(sec => sec.id !== action.sectionId) }
+            : ch
+        ),
+      };
+    case "setSectionField":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? {
+                ...ch,
+                sections: ch.sections.map(sec =>
+                  sec.id === action.sectionId ? { ...sec, [action.field]: action.value } : sec
+                ),
+              }
+            : ch
+        ),
+      };
+    case "addSubsection":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? {
+                ...ch,
+                sections: ch.sections.map(sec =>
+                  sec.id === action.sectionId
+                    ? { ...sec, subsections: [...sec.subsections, emptySubsection()] }
+                    : sec
+                ),
+              }
+            : ch
+        ),
+      };
+    case "removeSubsection":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? {
+                ...ch,
+                sections: ch.sections.map(sec =>
+                  sec.id === action.sectionId
+                    ? {
+                        ...sec,
+                        subsections: sec.subsections.filter(sub => sub.id !== action.subsectionId),
+                      }
+                    : sec
+                ),
+              }
+            : ch
+        ),
+      };
+    case "setSubsectionField":
+      return {
+        ...state,
+        chapters: state.chapters.map(ch =>
+          ch.id === action.chapterId
+            ? {
+                ...ch,
+                sections: ch.sections.map(sec =>
+                  sec.id === action.sectionId
+                    ? {
+                        ...sec,
+                        subsections: sec.subsections.map(sub =>
+                          sub.id === action.subsectionId ? { ...sub, [action.field]: action.value } : sub
+                        ),
+                      }
+                    : sec
+                ),
+              }
+            : ch
+        ),
+      };
+    default:
+      return state;
+  }
 }
 
 export default function ThesisForm() {
-  const [form, setForm] = useState({
-    title: "",
-    author: "",
-    advisor: "",
-    university: defaultUniversity,
-    year: "",
-    department: "",
-    abstract: "",
-    keywords: "",
-    chapters: [emptyChapter()],
-    bibliography: ""
-  });
+  const [form, dispatch] = useReducer(reducer, initialState);
 
-  // 章節管理
-  const addChapter = () => {
-    setForm(f => ({ ...f, chapters: [...f.chapters, emptyChapter()] }));
-  };
-  const removeChapter = idx => {
-    setForm(f => ({ ...f, chapters: f.chapters.filter((_, i) => i !== idx) }));
-  };
-  const setChapterField = (idx, key, value) => {
-    const chapters = [...form.chapters];
-    chapters[idx][key] = value;
-    setForm(f => ({ ...f, chapters }));
-  };
-  // 節管理
-  const addSection = cidx => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections.push(emptySection());
-    setForm(f => ({ ...f, chapters }));
-  };
-  const removeSection = (cidx, sidx) => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections = chapters[cidx].sections.filter((_, i) => i !== sidx);
-    setForm(f => ({ ...f, chapters }));
-  };
-  const setSectionField = (cidx, sidx, key, value) => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections[sidx][key] = value;
-    setForm(f => ({ ...f, chapters }));
-  };
-  // 小節管理
-  const addSubsection = (cidx, sidx) => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections[sidx].subsections.push(emptySubsection());
-    setForm(f => ({ ...f, chapters }));
-  };
-  const removeSubsection = (cidx, sidx, subidx) => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections[sidx].subsections = chapters[cidx].sections[sidx].subsections.filter((_, i) => i !== subidx);
-    setForm(f => ({ ...f, chapters }));
-  };
-  const setSubsectionField = (cidx, sidx, subidx, key, value) => {
-    const chapters = [...form.chapters];
-    chapters[cidx].sections[sidx].subsections[subidx][key] = value;
-    setForm(f => ({ ...f, chapters }));
-  };
-
-  // 產生 LaTeX
-  function renderLatex(form) {
-    // preamble (簡化版，可自行擴充)
-    let latex = `
-\\documentclass[12pt]{report}
-\\usepackage{CJKutf8}
-\\begin{document}
-\\begin{CJK}{UTF8}{bsmi}
-
-\\title{${form.title}}
-\\author{${form.author}}
-\\date{${form.year}}
-\\maketitle
-
-\\begin{center}
-${form.university} ${form.department}\\\\
-指導教授：${form.advisor}\\\\
-\\end{center}
-
-\\begin{abstract}
-${form.abstract}
-\\end{abstract}
-
-\\textbf{關鍵字：}${form.keywords}
-
-\\tableofcontents
-`;
-    // chapters
-    form.chapters.forEach((ch, cidx) => {
-      if (ch.title) latex += `\n\\chapter{${ch.title}}\n`;
-      ch.sections.forEach((sec, sidx) => {
+  function renderLatex(f) {
+    let latex = `\\documentclass[12pt]{report}\n`;
+    latex += "\\usepackage{CJKutf8}\n";
+    latex += "\\begin{document}\n\\begin{CJK}{UTF8}{bsmi}\n";
+    latex += `\\title{${f.title}}\n`;
+    latex += `\\author{${f.author}}\n`;
+    latex += `\\date{${f.year}}\n`;
+    latex += "\\maketitle\n";
+    latex += "\\begin{center}\n";
+    latex += `${f.university} ${f.department}\\\\\n`;
+    latex += `指導教授：${f.advisor}\\\\\n`;
+    latex += "\\end{center}\n";
+    latex += "\\begin{abstract}\n" + f.abstract + "\n\\end{abstract}\n";
+    latex += "\\textbf{關鍵字：}" + f.keywords + "\n";
+    latex += "\\tableofcontents\n";
+    f.chapters.forEach(ch => {
+      if (ch.title) latex += `\\chapter{${ch.title}}\n`;
+      ch.sections.forEach(sec => {
         if (sec.title) latex += `\\section{${sec.title}}\n`;
-        sec.subsections.forEach((sub, subidx) => {
+        sec.subsections.forEach(sub => {
           if (sub.title) latex += `\\subsection{${sub.title}}\n`;
           if (sub.content) latex += sub.content + "\n";
         });
       });
     });
-    // bibliography
-    latex += `\n\\chapter*{參考文獻}\n`;
-    form.bibliography.split("\n").forEach(line => {
+    latex += `\\chapter*{參考文獻}\n`;
+    f.bibliography.split("\n").forEach(line => {
       if (line.trim()) latex += `\\noindent ${line}\\\\\n`;
     });
-    latex += `\\end{CJK}\n\\end{document}`;
+    latex += "\\end{CJK}\n\\end{document}";
     return latex;
-  }
-
-  // 產生 docx（標題、目錄、表格、結構）
-  async function generateDocx(form) {
-    const docChildren = [];
-    // 封面
-    docChildren.push(
-      new Paragraph({
-        children: [
-          new TextRun({ text: form.title, bold: true, size: 56 }),
-        ],
-        heading: HeadingLevel.TITLE,
-        spacing: { after: 400 },
-        alignment: "center",
-      }),
-      new Paragraph({
-        children: [new TextRun({ text: form.author, size: 32 })],
-        alignment: "center",
-      }),
-      new Paragraph({
-        children: [new TextRun({ text: form.university + " " + form.department, size: 32 })],
-        alignment: "center",
-      }),
-      new Paragraph({
-        children: [new TextRun({ text: `指導教授：${form.advisor}`, size: 32 })],
-        alignment: "center",
-      }),
-      new Paragraph({
-        children: [new TextRun({ text: `學年度：${form.year}`, size: 32 })],
-        alignment: "center",
-      }),
-      new Paragraph({ text: "", spacing: { after: 200 } })
-    );
-    // 摘要 & 關鍵字
-    docChildren.push(
-      new Paragraph({ text: "摘要", heading: HeadingLevel.HEADING_1 }),
-      new Paragraph(form.abstract || ""),
-      new Paragraph({ text: "關鍵字：" + form.keywords, spacing: { after: 200 } })
-    );
-    // 目錄
-    docChildren.push(new Paragraph({ text: "目錄", heading: HeadingLevel.HEADING_1 }));
-    docChildren.push(
-      new TableOfContents("內容目錄", {
-        hyperlink: true,
-        headingStyleRange: "1-3"
-      })
-    );
-    // 章節
-    form.chapters.forEach((ch, cidx) => {
-      if (ch.title) docChildren.push(new Paragraph({ text: ch.title, heading: HeadingLevel.HEADING_1 }));
-      ch.sections.forEach((sec, sidx) => {
-        if (sec.title) docChildren.push(new Paragraph({ text: sec.title, heading: HeadingLevel.HEADING_2 }));
-        sec.subsections.forEach((sub, subidx) => {
-          if (sub.title) docChildren.push(new Paragraph({ text: sub.title, heading: HeadingLevel.HEADING_3 }));
-          if (sub.content) {
-            // 若偵測到是 Markdown 表格
-            if (isMarkdownTable(sub.content)) {
-              const tbl = parseMarkdownTable(sub.content);
-              if (tbl) docChildren.push(tbl);
-            } else {
-              // 一般文字
-              docChildren.push(...sub.content.split("\n").map(txt => new Paragraph(txt)));
-            }
-          }
-        });
-      });
-    });
-    // 參考文獻
-    docChildren.push(new Paragraph({ text: "參考文獻", heading: HeadingLevel.HEADING_1 }));
-    docChildren.push(
-      ...form.bibliography.split("\n").filter(Boolean).map(line => new Paragraph(line))
-    );
-    // 產生
-    const doc = new Document({
-      sections: [{ children: docChildren }],
-    });
-    const blob = await Packer.toBlob(doc);
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "thesis.docx";
-    a.click();
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
   return (
@@ -235,71 +180,66 @@ ${form.abstract}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label>論文標題</label>
-              <Input value={form.title} onChange={e=>setForm(f=>({...f,title:e.target.value}))} />
+              <Input value={form.title} onChange={e => dispatch({ type: "setField", field: "title", value: e.target.value })} />
             </div>
             <div>
               <label>作者</label>
-              <Input value={form.author} onChange={e=>setForm(f=>({...f,author:e.target.value}))} />
+              <Input value={form.author} onChange={e => dispatch({ type: "setField", field: "author", value: e.target.value })} />
             </div>
             <div>
               <label>指導教授</label>
-              <Input value={form.advisor} onChange={e=>setForm(f=>({...f,advisor:e.target.value}))} />
+              <Input value={form.advisor} onChange={e => dispatch({ type: "setField", field: "advisor", value: e.target.value })} />
             </div>
             <div>
               <label>學校</label>
-              <Input value={form.university} onChange={e=>setForm(f=>({...f,university:e.target.value}))} />
+              <Input value={form.university} onChange={e => dispatch({ type: "setField", field: "university", value: e.target.value })} />
             </div>
             <div>
               <label>學年度</label>
-              <Input value={form.year} onChange={e=>setForm(f=>({...f,year:e.target.value}))} />
+              <Input value={form.year} onChange={e => dispatch({ type: "setField", field: "year", value: e.target.value })} />
             </div>
             <div>
               <label>學位／科系</label>
-              <Input value={form.department} onChange={e=>setForm(f=>({...f,department:e.target.value}))} />
+              <Input value={form.department} onChange={e => dispatch({ type: "setField", field: "department", value: e.target.value })} />
             </div>
             <div className="md:col-span-2">
               <label>摘要</label>
-              <Textarea rows={3} value={form.abstract} onChange={e=>setForm(f=>({...f,abstract:e.target.value}))} />
+              <Textarea rows={3} value={form.abstract} onChange={e => dispatch({ type: "setField", field: "abstract", value: e.target.value })} />
             </div>
             <div className="md:col-span-2">
               <label>關鍵字（用逗號分隔）</label>
-              <Input value={form.keywords} onChange={e=>setForm(f=>({...f,keywords:e.target.value}))} />
+              <Input value={form.keywords} onChange={e => dispatch({ type: "setField", field: "keywords", value: e.target.value })} />
             </div>
           </div>
           <div>
             <h2 className="text-xl mt-2 mb-1 font-bold">章節內容</h2>
             {form.chapters.map((ch, cidx) => (
-              <div key={cidx} className="border rounded-xl p-3 mb-3 bg-slate-50">
-                <div className="flex items-center gap-2 mb-2">
-                  <Input placeholder={`第${cidx+1}章 標題`} value={ch.title} onChange={e=>setChapterField(cidx,"title",e.target.value)} />
-                  <Button variant="destructive" size="sm" onClick={()=>removeChapter(cidx)} disabled={form.chapters.length===1}>刪除章</Button>
-                </div>
-                {ch.sections.map((sec, sidx) => (
-                  <div key={sidx} className="pl-4 mb-2 border-l-2 border-gray-300">
-                    <div className="flex items-center gap-2 mb-1">
-                      <Input placeholder={`第${cidx+1}.${sidx+1}節 標題`} value={sec.title} onChange={e=>setSectionField(cidx,sidx,"title",e.target.value)} />
-                      <Button variant="outline" size="sm" onClick={()=>removeSection(cidx,sidx)} disabled={ch.sections.length===1}>刪除節</Button>
-                      <Button variant="outline" size="sm" onClick={()=>addSubsection(cidx,sidx)}>新增小節</Button>
-                    </div>
-                    {sec.subsections.map((sub, subidx) => (
-                      <div key={subidx} className="pl-4 mb-2 border-l border-gray-200">
-                        <div className="flex items-center gap-2 mb-1">
-                          <Input placeholder={`第${cidx+1}.${sidx+1}.${subidx+1}小節 標題`} value={sub.title} onChange={e=>setSubsectionField(cidx,sidx,subidx,"title",e.target.value)} />
-                          <Button variant="outline" size="sm" onClick={()=>removeSubsection(cidx,sidx,subidx)} disabled={sec.subsections.length===1}>刪除小節</Button>
-                        </div>
-                        <Textarea rows={2} placeholder="小節內容 (可用Markdown表格格式)" value={sub.content} onChange={e=>setSubsectionField(cidx,sidx,subidx,"content",e.target.value)} />
-                      </div>
-                    ))}
-                    <Button variant="outline" size="sm" onClick={()=>addSection(cidx)} className="mt-2">新增節</Button>
-                  </div>
-                ))}
-              </div>
+              <ChapterEditor
+                key={ch.id}
+                chapter={ch}
+                index={cidx}
+                onChangeTitle={val => dispatch({ type: "setChapterField", id: ch.id, field: "title", value: val })}
+                onAddSection={() => dispatch({ type: "addSection", chapterId: ch.id })}
+                onRemove={() => dispatch({ type: "removeChapter", id: ch.id })}
+                onUpdateSection={(secId, field, val) => dispatch({ type: "setSectionField", chapterId: ch.id, sectionId: secId, field, value: val })}
+                onRemoveSection={secId => dispatch({ type: "removeSection", chapterId: ch.id, sectionId: secId })}
+                onAddSubsection={secId => dispatch({ type: "addSubsection", chapterId: ch.id, sectionId: secId })}
+                onUpdateSubsection={(secId, subId, field, val) => dispatch({ type: "setSubsectionField", chapterId: ch.id, sectionId: secId, subsectionId: subId, field, value: val })}
+                onRemoveSubsection={(secId, subId) => dispatch({ type: "removeSubsection", chapterId: ch.id, sectionId: secId, subsectionId: subId })}
+              />
             ))}
-            <Button variant="default" onClick={addChapter} className="mt-2">新增章節</Button>
+            <Button variant="default" onClick={() => dispatch({ type: "addChapter" })} className="mt-2">
+              新增章節
+            </Button>
           </div>
           <div>
             <h2 className="text-xl mt-2 mb-1 font-bold">參考文獻</h2>
-            <Textarea rows={3} value={form.bibliography} onChange={e=>setForm(f=>({...f,bibliography:e.target.value}))} placeholder="每行一條文獻" />
+            <Textarea
+              rows={3}
+              value={form.bibliography}
+              onChange={e => dispatch({ type: "setField", field: "bibliography", value: e.target.value })}
+              placeholder="每行一條文獻"
+            />
           </div>
         </CardContent>
       </Card>
@@ -318,10 +258,10 @@ ${form.abstract}
             a.click();
             setTimeout(() => URL.revokeObjectURL(url), 1000);
           }}
-        >下載 .tex</Button>
-        <Button
-          onClick={() => generateDocx(form)}
-        >下載 .docx</Button>
+        >
+          下載 .tex
+        </Button>
+        <Button onClick={() => generateDocx(form)}>下載 .docx</Button>
       </div>
     </div>
   );

--- a/src/components/thesis/ChapterEditor.jsx
+++ b/src/components/thesis/ChapterEditor.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import SectionEditor from "./SectionEditor";
+
+export default function ChapterEditor({
+  chapter,
+  index,
+  onChangeTitle,
+  onAddSection,
+  onRemove,
+  onUpdateSection,
+  onRemoveSection,
+  onAddSubsection,
+  onUpdateSubsection,
+  onRemoveSubsection,
+}) {
+  return (
+    <div className="border rounded-xl p-3 mb-3 bg-slate-50">
+      <div className="flex items-center gap-2 mb-2">
+        <Input
+          placeholder={`第${index + 1}章 標題`}
+          value={chapter.title}
+          onChange={e => onChangeTitle(e.target.value)}
+        />
+        <Button variant="destructive" size="sm" onClick={onRemove} disabled={false}>
+          刪除章
+        </Button>
+      </div>
+      {chapter.sections.map((sec, sidx) => (
+        <SectionEditor
+          key={sec.id}
+          section={sec}
+          chapterIndex={index}
+          index={sidx}
+          onChangeTitle={val => onUpdateSection(sec.id, "title", val)}
+          onAddSubsection={() => onAddSubsection(sec.id)}
+          onRemove={() => onRemoveSection(sec.id)}
+          onUpdateSubsection={(subId, field, val) =>
+            onUpdateSubsection(sec.id, subId, field, val)
+          }
+          onRemoveSubsection={subId => onRemoveSubsection(sec.id, subId)}
+        />
+      ))}
+      <Button variant="outline" size="sm" className="mt-2" onClick={onAddSection}>
+        新增節
+      </Button>
+    </div>
+  );
+}

--- a/src/components/thesis/SectionEditor.jsx
+++ b/src/components/thesis/SectionEditor.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import SubsectionEditor from "./SubsectionEditor";
+
+export default function SectionEditor({
+  section,
+  chapterIndex,
+  index,
+  onChangeTitle,
+  onAddSubsection,
+  onRemove,
+  onUpdateSubsection,
+  onRemoveSubsection,
+}) {
+  return (
+    <div className="pl-4 mb-2 border-l-2 border-gray-300">
+      <div className="flex items-center gap-2 mb-1">
+        <Input
+          placeholder={`第${chapterIndex + 1}.${index + 1}節 標題`}
+          value={section.title}
+          onChange={e => onChangeTitle(e.target.value)}
+        />
+        <Button variant="outline" size="sm" onClick={onRemove} disabled={false}>
+          刪除節
+        </Button>
+        <Button variant="outline" size="sm" onClick={onAddSubsection}>
+          新增小節
+        </Button>
+      </div>
+      {section.subsections.map((sub, subidx) => (
+        <SubsectionEditor
+          key={sub.id}
+          subsection={sub}
+          index={subidx}
+          onChangeTitle={val => onUpdateSubsection(sub.id, "title", val)}
+          onChangeContent={val => onUpdateSubsection(sub.id, "content", val)}
+          onRemove={() => onRemoveSubsection(sub.id)}
+          disableRemove={section.subsections.length === 1}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/thesis/SubsectionEditor.jsx
+++ b/src/components/thesis/SubsectionEditor.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import { Button } from "../ui/button";
+
+export default function SubsectionEditor({ subsection, index, onChangeTitle, onChangeContent, onRemove, disableRemove }) {
+  return (
+    <div className="pl-4 mb-2 border-l border-gray-200">
+      <div className="flex items-center gap-2 mb-1">
+        <Input
+          placeholder={`小節${index + 1} 標題`}
+          value={subsection.title}
+          onChange={e => onChangeTitle(e.target.value)}
+        />
+        <Button variant="outline" size="sm" onClick={onRemove} disabled={disableRemove}>
+          刪除小節
+        </Button>
+      </div>
+      <Textarea
+        rows={2}
+        placeholder="小節內容 (可用Markdown表格格式)"
+        value={subsection.content}
+        onChange={e => onChangeContent(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/src/utils/docx.js
+++ b/src/utils/docx.js
@@ -1,0 +1,69 @@
+import { Document, Packer, Paragraph, HeadingLevel, TextRun, Table, TableRow, TableCell, TableOfContents } from "docx";
+
+export function isMarkdownTable(text) {
+  return text.trim().split("\n")[0].trim().startsWith("|") && text.includes("|---");
+}
+
+export function parseMarkdownTable(md) {
+  const lines = md.trim().split("\n").filter(Boolean);
+  if (lines.length < 2) return null;
+  const rows = lines.filter(l => l.trim().startsWith("|"));
+  const data = rows.map(r => r.split("|").slice(1, -1).map(cell => cell.trim()));
+  const tableRows = data.filter(row => !row.every(cell => cell.match(/^[-:]+$/)));
+  return new Table({
+    rows: tableRows.map(row => new TableRow({
+      children: row.map(cell => new TableCell({ children: [new Paragraph(cell)] }))
+    }))
+  });
+}
+
+export async function generateDocx(form) {
+  const docChildren = [];
+  docChildren.push(
+    new Paragraph({
+      children: [new TextRun({ text: form.title, bold: true, size: 56 })],
+      heading: HeadingLevel.TITLE,
+      spacing: { after: 400 },
+      alignment: "center",
+    }),
+    new Paragraph({ children: [new TextRun({ text: form.author, size: 32 })], alignment: "center" }),
+    new Paragraph({ children: [new TextRun({ text: form.university + " " + form.department, size: 32 })], alignment: "center" }),
+    new Paragraph({ children: [new TextRun({ text: `指導教授：${form.advisor}`, size: 32 })], alignment: "center" }),
+    new Paragraph({ children: [new TextRun({ text: `學年度：${form.year}`, size: 32 })], alignment: "center" }),
+    new Paragraph({ text: "", spacing: { after: 200 } })
+  );
+  docChildren.push(
+    new Paragraph({ text: "摘要", heading: HeadingLevel.HEADING_1 }),
+    new Paragraph(form.abstract || ""),
+    new Paragraph({ text: "關鍵字：" + form.keywords, spacing: { after: 200 } })
+  );
+  docChildren.push(new Paragraph({ text: "目錄", heading: HeadingLevel.HEADING_1 }));
+  docChildren.push(new TableOfContents("內容目錄", { hyperlink: true, headingStyleRange: "1-3" }));
+  form.chapters.forEach(ch => {
+    if (ch.title) docChildren.push(new Paragraph({ text: ch.title, heading: HeadingLevel.HEADING_1 }));
+    ch.sections.forEach(sec => {
+      if (sec.title) docChildren.push(new Paragraph({ text: sec.title, heading: HeadingLevel.HEADING_2 }));
+      sec.subsections.forEach(sub => {
+        if (sub.title) docChildren.push(new Paragraph({ text: sub.title, heading: HeadingLevel.HEADING_3 }));
+        if (sub.content) {
+          if (isMarkdownTable(sub.content)) {
+            const tbl = parseMarkdownTable(sub.content);
+            if (tbl) docChildren.push(tbl);
+          } else {
+            docChildren.push(...sub.content.split("\n").map(txt => new Paragraph(txt)));
+          }
+        }
+      });
+    });
+  });
+  docChildren.push(new Paragraph({ text: "參考文獻", heading: HeadingLevel.HEADING_1 }));
+  docChildren.push(...form.bibliography.split("\n").filter(Boolean).map(line => new Paragraph(line)));
+  const doc = new Document({ sections: [{ children: docChildren }] });
+  const blob = await Packer.toBlob(doc);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "thesis.docx";
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}


### PR DESCRIPTION
## Summary
- add docx utilities with table parsing and generation helpers
- implement chapter/section/subsection editors
- refactor `ThesisForm` to use reducers and editor components
- generate unique ids for thesis structure

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842db38bb68832ca1bcea340b71f612